### PR TITLE
Fix #26 	Executor が日本語を出力するとコケる

### DIFF
--- a/app/executors/executor.rb
+++ b/app/executors/executor.rb
@@ -62,8 +62,8 @@ class Executor
       container.kill
     end
 
-    stdout = container.streaming_logs(stdout: true)
-    stderr = container.streaming_logs(stderr: true)
+    stdout = container.streaming_logs(stdout: true).force_encoding("UTF-8")
+    stderr = container.streaming_logs(stderr: true).force_encoding("UTF-8")
     rc = container.wait["StatusCode"]
 
     [

--- a/spec/executors/executor_environment/bash_spec.rb
+++ b/spec/executors/executor_environment/bash_spec.rb
@@ -28,6 +28,19 @@ RSpec.describe ExecutorEnvironment::Bash do
           expect(rc).to eq 0
         end
       end
+
+      it '"日本語テキスト" を標準出力、標準エラー出力するコードを与えると、stdout と stderr が "日本語テキスト\n"、rc が 0 で返ること' do
+        stdout, stderr, rc = bash_executor.run!(<<~BASH)
+          echo "日本語テキスト"
+          echo "日本語テキスト" >&2
+        BASH
+
+        aggregate_failures do
+          expect(stdout).to eq "日本語テキスト\n"
+          expect(stderr).to eq "日本語テキスト\n"
+          expect(rc).to eq 0
+        end
+      end
     end
 
     context "エラーが発生するコードを与えたとき" do


### PR DESCRIPTION
close #26